### PR TITLE
Next: Refactoring to support Nette v3

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,7 +1,8 @@
-# Application
+# Contributte Application
 
 ## Content
 
+- [Setup](#setup)
 - [UI](#ui)
     - [Presenter](#presenter)
         - [StructuredTemplates](#structured-templates)
@@ -15,6 +16,12 @@
     - [FlyResponse - send file/buffer on-the-fly](#flyresponse)
     - [XmlResponse](#xmlresponse)
     - [StringResponse](#stringresponse)
+
+## Setup
+
+```bash
+composer require contributte/application
+```
 
 ## UI
 
@@ -163,7 +170,6 @@ $this->sendResponse($response);
 
 ```php
 use Contributte\Application\Response\Fly\Adapter\CallbackAdapter;
-use Contributte\Application\Response\Fly\Buffer\Buffer;
 use Contributte\Application\Response\Fly\FlyFileResponse;
 use Nette\Http\IRequest;
 use Nette\Http\IResponse;

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+Makefile export-ignore
 phpstan.neon export-ignore
 README.md export-ignore
 ruleset.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,55 @@
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
+  - nightly
 
 before_install:
-# Turn off XDebug
-- phpenv config-rm xdebug.ini || return 0
+  - phpenv config-rm xdebug.ini || return 0 # Turn off XDebug
 
 install:
-  # Composer
-  - travis_retry composer install --no-progress --prefer-dist
+  - travis_retry composer install --no-progress --prefer-dist # Install dependencies
 
 script:
-  # Tests
-  - composer run-script tests
+  - make tests # Tests
 
 after_failure:
-  # Print *.actual content
-  - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+  - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done # Print *.actual content
 
 jobs:
   include:
-    - env: title="Lowest Dependencies 7.1"
-      php: 7.1
+    - env: title="Lowest Dependencies 7.2"
+      php: 7.2
       install:
-        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
+        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable
       script:
-        - composer run-script tests
+        - make tests
 
     - stage: Quality Assurance
-      php: 7.1
+      php: 7.3
       script:
-        - composer run-script qa
-
-    - stage: Phpstan
-      php: 7.1
-      script:
-        - composer run-script phpstan
+        - make qa
 
     - stage: Test Coverage
       if: branch = master AND type = push
-      php: 7.1
+      php: 7.3
       script:
-        - composer run-script coverage
+        - make coverage
       after_script:
-        - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
-        - php php-coveralls.phar --verbose --config tests/.coveralls.yml
+        - composer global require php-coveralls/php-coveralls ^2.1.0
+        - ~/.composer/vendor/bin/php-coveralls --verbose --config tests/.coveralls.yml
 
     - stage: Outdated Dependencies
       if: branch = master AND type = cron
-      php: 7.1
+      php: 7.3
       script:
-        - composer outdated --direct --strict
+        - composer outdated --direct
 
   allow_failures:
     - stage: Test Coverage
+    - php: 7.4snapshot
+    - php: nightly
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: qa lint cs csf phpstan tests coverage
+
+all:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+
+vendor: composer.json composer.lock
+	composer install
+
+qa: lint phpstan cs
+
+lint: vendor
+	vendor/bin/linter src tests
+
+cs: vendor
+	vendor/bin/codesniffer src tests
+
+csf: vendor
+	vendor/bin/codefixer src tests
+
+phpstan: vendor
+	vendor/bin/phpstan analyse -l max -c phpstan.neon src
+
+tests: vendor
+	vendor/bin/tester -s -p php --colors 1 -C tests/cases
+
+coverage: vendor
+	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Contributte > Application
+# Contributte Application
 
-:sparkles: Extra contribution to [`nette/application`](https://github.com/nette/application).
-
------
+Extra contribution to [`nette/application`](https://github.com/nette/application).
 
 [![Build Status](https://img.shields.io/travis/contributte/application.svg?style=flat-square)](https://travis-ci.org/contributte/application)
 [![Code coverage](https://img.shields.io/coveralls/contributte/application.svg?style=flat-square)](https://coveralls.io/r/contributte/application)
@@ -10,40 +8,36 @@
 [![Downloads this Month](https://img.shields.io/packagist/dm/contributte/application.svg?style=flat-square)](https://packagist.org/packages/contributte/application)
 [![Downloads total](https://img.shields.io/packagist/dt/contributte/application.svg?style=flat-square)](https://packagist.org/packages/contributte/application)
 [![Latest stable](https://img.shields.io/packagist/v/contributte/application.svg?style=flat-square)](https://packagist.org/packages/contributte/application)
-[![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat)](https://github.com/phpstan/phpstan)
+[![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat-square)](https://github.com/phpstan/phpstan)
 
 ## Discussion / Help
 
 [![Join the chat](https://img.shields.io/gitter/room/contributte/contributte.svg?style=flat-square)](http://bit.ly/ctteg)
 
-## Install
+## Documentation
 
-```
-composer require contributte/application
-```
+- [Setup](.docs/README.md#setup)
+- [UI](.docs/README.md#ui)
+    - [Presenter](.docs/README.md#presenter)
+        - [StructuredTemplates](.docs/README.md#structured-templates)
+    - [Control](.docs/README.md#control)
+    - [Component](.docs/README.md#component)
+- [Responses](.docs/README.md#responses)
+    - [CSVResponse](.docs/README.md#csvresponse)
+    - [ImageResponse](.docs/README.md#imageresponse)
+    - [JsonPrettyResponse](.docs/README.md#psr7streamresponse)
+    - [PSR7StreamResponse](.docs/README.md#flyresponse)
+    - [FlyResponse - send file/buffer on-the-fly](.docs/README.md#flyresponse)
+    - [XmlResponse](.docs/README.md#xmlresponse)
 
 ## Versions
 
-| State       | Version | Branch   | PHP      |
-|-------------|---------|----------|----------|
-| development | `^0.4`  | `master` | `>= 7.1` |
-| stable      | `^0.3`  | `master` | `>= 7.1` |
-| stable      | `^0.2`  | `master` | `>= 5.6` |
-
-## Overview
-
-- [UI](https://github.com/contributte/application/blob/master/.docs/README.md#ui)
-    - [Presenter](https://github.com/contributte/application/blob/master/.docs/README.md#presenter)
-        - [StructuredTemplates](https://github.com/contributte/application/blob/master/.docs/README.md#structured-templates)
-    - [Control](https://github.com/contributte/application/blob/master/.docs/README.md#control)
-    - [Component](https://github.com/contributte/application/blob/master/.docs/README.md#component)
-- [Responses](https://github.com/contributte/application/blob/master/.docs/README.md#responses)
-    - [CSVResponse](https://github.com/contributte/application/blob/master/.docs/README.md#csvresponse)
-    - [ImageResponse](https://github.com/contributte/application/blob/master/.docs/README.md#imageresponse)
-    - [JsonPrettyResponse](https://github.com/contributte/application/blob/master/.docs/README.md#psr7streamresponse)
-    - [PSR7StreamResponse](https://github.com/contributte/application/blob/master/.docs/README.md#flyresponse)
-    - [FlyResponse - send file/buffer on-the-fly](https://github.com/contributte/application/blob/master/.docs/README.md#flyresponse)
-    - [XmlResponse](https://github.com/contributte/application/blob/master/.docs/README.md#xmlresponse)
+| State       | Version | Branch   | Nette | PHP     |
+|-------------|---------|----------|-------|---------|
+| dev         | `^0.5`  | `master` | 3.0+  | `^7.2`  |
+| stable      | `^0.4`  | `master` | 3.0+  | `^7.2`  |
+| stable      | `^0.3`  | `master` | 2.4   | `>=7.1` |
+| stable      | `^0.2`  | `master` | 2.4   | `>=5.6` |
 
 ## Maintainers
 

--- a/composer.json
+++ b/composer.json
@@ -12,45 +12,39 @@
     }
   ],
   "require": {
-    "php": ">= 7.1",
-    "nette/application": "~2.4.11 || ~3.0.0"
+    "php": "^7.2",
+    "nette/application": "~3.0.0"
   },
   "require-dev": {
-    "ninjify/qa": "^0.9.0",
-    "ninjify/nunjuck": "^0.2.0",
     "nette/http": "~2.4.8 || ~3.0.0",
-    "psr/http-message": "~1.0.1",
-    "tracy/tracy": "~2.6.1",
-    "phpstan/phpstan-shim": "^0.11.2",
+    "ninjify/nunjuck": "^0.2.0",
+    "ninjify/qa": "^0.9.0",
+    "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan-deprecation-rules": "^0.11.0",
     "phpstan/phpstan-nette": "^0.11.1",
-    "phpstan/phpstan-strict-rules": "^0.11.0"
+    "phpstan/phpstan-shim": "^0.11.2",
+    "phpstan/phpstan-strict-rules": "^0.11.0",
+    "psr/http-message": "~1.0.1",
+    "tracy/tracy": "~2.6.1"
   },
   "autoload": {
     "psr-4": {
       "Contributte\\Application\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\Cases\\": "tests/cases"
+    }
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "scripts": {
-    "qa": [
-      "linter src tests",
-      "codesniffer src tests"
-    ],
-    "tests": [
-      "tester -s -p php --colors 1 -C tests/cases"
-    ],
-    "coverage": [
-      "tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases"
-    ],
-    "phpstan": [
-      "vendor/bin/phpstan analyse -l max -c phpstan.neon src"
-    ]
+  "config": {
+    "sort-packages": true
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.4.x-dev"
+      "dev-next": "0.5.x-dev"
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,3 @@
-includes:
-	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
-	- vendor/phpstan/phpstan-nette/extension.neon
-	- vendor/phpstan/phpstan-nette/rules.neon
-	- vendor/phpstan/phpstan-strict-rules/rules.neon
-
 parameters:
 	ignoreErrors:
 		- '#^Property Contributte\\Application\\Response\\Fly\\Buffer\\(FileBuffer|ProcessBuffer)\:\:\$pointer \(resource\) does not accept resource\|false\.$#'

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0"?>
-<ruleset name="Contributte">
-    <!-- Contributte Coding Standard -->
-    <rule ref="./vendor/ninjify/coding-standard/contributte.xml">
-        <exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator.TernaryOperatorNotUsed" />
-        <exclude name="SlevomatCodingStandard.PHP.TypeCast" />
-    </rule>
+<ruleset>
+	<!-- Contributte Coding Standard -->
+	<rule ref="./vendor/ninjify/coding-standard/contributte.xml">
+		<exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator.TernaryOperatorNotUsed" />
+		<exclude name="SlevomatCodingStandard.PHP.TypeCast" />
+	</rule>
 
-    <!-- Specific rules -->
-    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
-        <properties>
-            <property name="rootNamespaces" type="array" value="
-                src=>Contributte\Application,
-                tests/fixtures=>Tests\Fixtures
-            "/>
-        </properties>
-    </rule>
+	<!-- Specific rules -->
+	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+		<properties>
+			<property name="rootNamespaces" type="array" value="
+				src=>Contributte\Application,
+				tests/cases=>Tests\Cases,
+				tests/fixtures=>Tests\Fixtures
+			"/>
+		</properties>
+	</rule>
 
-    <!--Exclude folders -->
-    <exclude-pattern>/tests/tmp</exclude-pattern>
+	<!--Exclude folders -->
+	<exclude-pattern>/tests/tmp</exclude-pattern>
 </ruleset>

--- a/src/Response/JsonPrettyResponse.php
+++ b/src/Response/JsonPrettyResponse.php
@@ -2,19 +2,34 @@
 
 namespace Contributte\Application\Response;
 
-use Nette\Application\Responses\JsonResponse;
+use Nette\Application\IResponse;
 use Nette\Http\IRequest as IHttpRequest;
 use Nette\Http\IResponse as IHttpResponse;
 use Nette\Utils\Json;
 
-/**
- * Add JSON_PRETTY_PRINT option to Nette\Application\Responses\JsonResponse
- */
-class JsonPrettyResponse extends JsonResponse
+class JsonPrettyResponse implements IResponse
 {
 
 	/** @var int */
 	private $code = IHttpResponse::S200_OK;
+
+	/** @var mixed */
+	private $payload;
+
+	/** @var string */
+	private $contentType;
+
+	/** @var string|null */
+	private $expiration;
+
+	/**
+	 * @param mixed $payload
+	 */
+	public function __construct($payload, ?string $contentType = null)
+	{
+		$this->payload = $payload;
+		$this->contentType = $contentType ?: 'application/json';
+	}
 
 	public function setCode(int $code): void
 	{
@@ -26,10 +41,38 @@ class JsonPrettyResponse extends JsonResponse
 		return $this->code;
 	}
 
+	public function getContentType(): string
+	{
+		return $this->contentType;
+	}
+
+	public function setContentType(string $contentType): void
+	{
+		$this->contentType = $contentType;
+	}
+
+	public function getExpiration(): ?string
+	{
+		return $this->expiration;
+	}
+
+	public function setExpiration(?string $expiration): void
+	{
+		$this->expiration = $expiration;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getPayload()
+	{
+		return $this->payload;
+	}
+
 	public function send(IHttpRequest $httpRequest, IHttpResponse $httpResponse): void
 	{
 		$httpResponse->setContentType($this->getContentType(), 'utf-8');
-		$httpResponse->setExpiration(false);
+		$httpResponse->setExpiration($this->expiration);
 		$httpResponse->setCode($this->code);
 
 		echo Json::encode($this->getPayload(), Json::PRETTY);

--- a/src/Response/PSR7StreamResponse.php
+++ b/src/Response/PSR7StreamResponse.php
@@ -13,25 +13,13 @@ use Psr\Http\Message\StreamInterface;
 final class PSR7StreamResponse implements IResponse
 {
 
-	/**
-	 * Instance of the response stream.
-	 *
-	 * @var StreamInterface
-	 */
+	/** @var StreamInterface */
 	private $stream;
 
-	/**
-	 * Name of the downloading file.
-	 *
-	 * @var string
-	 */
+	/** @var string */
 	private $name;
 
-	/**
-	 * Content-Type of the contents.
-	 *
-	 * @var string
-	 */
+	/** @var string */
 	private $contentType;
 
 	/**
@@ -73,7 +61,7 @@ final class PSR7StreamResponse implements IResponse
 	public function send(IHttpRequest $httpRequest, IHttpResponse $httpResponse): void
 	{
 		// Set response headers for the file download
-		$httpResponse->setHeader('Content-Length', $this->stream->getSize());
+		$httpResponse->setHeader('Content-Length', (string) $this->stream->getSize());
 		$httpResponse->setHeader('Content-Type', $this->contentType);
 		$httpResponse->setHeader('Content-Disposition', 'attachment; filename="' . $this->name . '";');
 

--- a/src/Response/XmlResponse.php
+++ b/src/Response/XmlResponse.php
@@ -2,17 +2,42 @@
 
 namespace Contributte\Application\Response;
 
-use Nette\Application\Responses\TextResponse;
-use Nette\Http\IRequest;
-use Nette\Http\IResponse;
+use Nette\Application\IResponse;
+use Nette\Application\UI\ITemplate;
+use Nette\Http\IRequest as IHttpRequest;
+use Nette\Http\IResponse as IHttpResponse;
 
-class XmlResponse extends TextResponse
+class XmlResponse implements IResponse
 {
 
-	public function send(IRequest $httpRequest, IResponse $httpResponse): void
+	/** @var mixed */
+	private $source;
+
+	/**
+	 * @param mixed $source
+	 */
+	public function __construct($source)
+	{
+		$this->source = $source;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getSource()
+	{
+		return $this->source;
+	}
+
+	public function send(IHttpRequest $httpRequest, IHttpResponse $httpResponse): void
 	{
 		$httpResponse->addHeader('Content-Type', 'text/xml');
-		parent::send($httpRequest, $httpResponse);
+
+		if ($this->source instanceof ITemplate) {
+			$this->source->render();
+		} else {
+			echo $this->source;
+		}
 	}
 
 }

--- a/tests/cases/Unit/Response/Fly/Buffer/FileBuffer.phpt
+++ b/tests/cases/Unit/Response/Fly/Buffer/FileBuffer.phpt
@@ -7,7 +7,7 @@
 use Contributte\Application\Response\Fly\Buffer\FileBuffer;
 use Tester\Assert;
 
-require_once __DIR__ . '/../../../../bootstrap.php';
+require_once __DIR__ . '/../../../../../bootstrap.php';
 
 test(function (): void {
 	$file = TEMP_DIR . '/test1.file' . time();

--- a/tests/cases/Unit/Response/Fly/Buffer/ProcessBuffer.phpt
+++ b/tests/cases/Unit/Response/Fly/Buffer/ProcessBuffer.phpt
@@ -7,7 +7,7 @@
 use Contributte\Application\Response\Fly\Buffer\ProcessBuffer;
 use Tester\Assert;
 
-require_once __DIR__ . '/../../../../bootstrap.php';
+require_once __DIR__ . '/../../../../../bootstrap.php';
 
 test(function (): void {
 	$b = new ProcessBuffer('date');


### PR DESCRIPTION
- Require PHP ^7.2
- Test against PHP 7.2-8.0
- Support new yummy nette/schema. Refactor configuration to allow pass any key needed.
- Refactor JsonPrettyResponse and XmlResponse because original classes in Nette are final.

----

```
{
  "require": {
    "contributte/application": "^0.5.0"
  }
}
```