### PR TITLE
Fix for encoding windows-1250 not working with mb_convert_encoding

### DIFF
--- a/src/Response/CSVResponse.php
+++ b/src/Response/CSVResponse.php
@@ -93,6 +93,8 @@ class CSVResponse implements IResponse
 
 			if (strtolower($this->outputEncoding) === 'utf-8') {
 				echo $csvRow;
+			} elseif (strtolower($this->outputEncoding) === 'windows-1250') {
+				echo iconv('utf-8', $this->outputEncoding, $csvRow);
 			} else {
 				echo mb_convert_encoding($csvRow, $this->outputEncoding);
 			}

--- a/tests/cases/Unit/Response/CsvResponse.phpt
+++ b/tests/cases/Unit/Response/CsvResponse.phpt
@@ -35,3 +35,15 @@ test(static function (): void {
 
 	Assert::equal($csvOutput, "a;b\nc;d\n");
 });
+
+test(static function (): void {
+	$csv = new CSVResponse([
+		['a', 'b'],
+		['c', 'd'],
+	], 'some.csv', 'windows-1250');
+	ob_start();
+	$csv->send(new Request(new UrlScript()), new Response());
+	$csvOutput = ob_get_clean();
+
+	Assert::equal($csvOutput, iconv('utf-8', 'windows-1250', "a;b\nc;d\n"));
+});


### PR DESCRIPTION
Windows-1250 encoding don't work with function mb_convert_encoding. Use of this function was introduced in #26 
This PR simply use iconv **only** for this encoding. 

New test included.