### PR TITLE
Replace addHeader with setHeader

### DIFF
--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -48,8 +48,8 @@ final class StringResponse implements IResponse
 
 	public function send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse): void
 	{
-		$httpResponse->addHeader('Content-Type', $this->contentType);
-		$httpResponse->addHeader(
+		$httpResponse->setHeader('Content-Type', $this->contentType);
+		$httpResponse->setHeader(
 			'Content-Disposition',
 			($this->attachment ? 'attachment;' : '') . 'filename="' . $this->name . '"'
 		);


### PR DESCRIPTION
Because addHeader doesn't replace already defined headers. Content-Type is already defined in HttpExtension in nette/http. Since nginx 1.23 it leads to malfunction.